### PR TITLE
Fix minor typo ("encountered" as "ancountered")

### DIFF
--- a/Fuoten/error.cpp
+++ b/Fuoten/error.cpp
@@ -156,7 +156,7 @@ Error::Error(QNetworkReply *reply, QObject *parent) :
                 d->text = qtTrId("libfuoten-err-http-431");
                 break;
             case 500:
-                //% "Internal server error — An unexpected condition was ancountered on the server."
+                //% "Internal server error — An unexpected condition was encountered on the server."
                 d->text = qtTrId("libfuoten-err-http-500");
                 break;
             case 501:

--- a/translations/libfuoten.ts
+++ b/translations/libfuoten.ts
@@ -235,7 +235,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message id="libfuoten-err-http-500">
-        <source>Internal server error — An unexpected condition was ancountered on the server.</source>
+        <source>Internal server error — An unexpected condition was encountered on the server.</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="libfuoten-err-http-501">

--- a/translations/libfuoten_da.ts
+++ b/translations/libfuoten_da.ts
@@ -230,7 +230,7 @@
         <translation type="unfinished"/>
     </message>
     <message id="libfuoten-err-http-500">
-        <source>Internal server error — An unexpected condition was ancountered on the server.</source>
+        <source>Internal server error — An unexpected condition was encountered on the server.</source>
         <translation type="unfinished"/>
     </message>
     <message id="libfuoten-err-http-501">

--- a/translations/libfuoten_de.ts
+++ b/translations/libfuoten_de.ts
@@ -230,7 +230,7 @@
         <translation>Header‐Felder der Anfrage zu groß – Der Server ist nicht gewillt, die Anfrage zu verarbeiten, weil entweder ein einzelnes Header-Feld oder alle Header-Felder gemeinsam zu groß sind.</translation>
     </message>
     <message id="libfuoten-err-http-500">
-        <source>Internal server error — An unexpected condition was ancountered on the server.</source>
+        <source>Internal server error — An unexpected condition was encountered on the server.</source>
         <translation>Interner Server‐Fehler – Auf dem Server wurde ein unerwarteter Zustand festgestellt.</translation>
     </message>
     <message id="libfuoten-err-http-501">

--- a/translations/libfuoten_el.ts
+++ b/translations/libfuoten_el.ts
@@ -230,7 +230,7 @@
         <translation type="unfinished"/>
     </message>
     <message id="libfuoten-err-http-500">
-        <source>Internal server error — An unexpected condition was ancountered on the server.</source>
+        <source>Internal server error — An unexpected condition was encountered on the server.</source>
         <translation type="unfinished"/>
     </message>
     <message id="libfuoten-err-http-501">

--- a/translations/libfuoten_en_GB.ts
+++ b/translations/libfuoten_en_GB.ts
@@ -230,7 +230,7 @@
         <translation type="unfinished"/>
     </message>
     <message id="libfuoten-err-http-500">
-        <source>Internal server error — An unexpected condition was ancountered on the server.</source>
+        <source>Internal server error — An unexpected condition was encountered on the server.</source>
         <translation type="unfinished"/>
     </message>
     <message id="libfuoten-err-http-501">

--- a/translations/libfuoten_en_US.ts
+++ b/translations/libfuoten_en_US.ts
@@ -230,7 +230,7 @@
         <translation type="unfinished"/>
     </message>
     <message id="libfuoten-err-http-500">
-        <source>Internal server error — An unexpected condition was ancountered on the server.</source>
+        <source>Internal server error — An unexpected condition was encountered on the server.</source>
         <translation type="unfinished"/>
     </message>
     <message id="libfuoten-err-http-501">

--- a/translations/libfuoten_fr.ts
+++ b/translations/libfuoten_fr.ts
@@ -230,7 +230,7 @@
         <translation type="unfinished"/>
     </message>
     <message id="libfuoten-err-http-500">
-        <source>Internal server error — An unexpected condition was ancountered on the server.</source>
+        <source>Internal server error — An unexpected condition was encountered on the server.</source>
         <translation type="unfinished"/>
     </message>
     <message id="libfuoten-err-http-501">

--- a/translations/libfuoten_it.ts
+++ b/translations/libfuoten_it.ts
@@ -230,7 +230,7 @@
         <translation type="unfinished"/>
     </message>
     <message id="libfuoten-err-http-500">
-        <source>Internal server error — An unexpected condition was ancountered on the server.</source>
+        <source>Internal server error — An unexpected condition was encountered on the server.</source>
         <translation type="unfinished"/>
     </message>
     <message id="libfuoten-err-http-501">

--- a/translations/libfuoten_nl.ts
+++ b/translations/libfuoten_nl.ts
@@ -230,7 +230,7 @@
         <translation type="unfinished"/>
     </message>
     <message id="libfuoten-err-http-500">
-        <source>Internal server error — An unexpected condition was ancountered on the server.</source>
+        <source>Internal server error — An unexpected condition was encountered on the server.</source>
         <translation type="unfinished"/>
     </message>
     <message id="libfuoten-err-http-501">

--- a/translations/libfuoten_sv.ts
+++ b/translations/libfuoten_sv.ts
@@ -230,7 +230,7 @@
         <translation>Begärans rubrikfält för stora — Servern är ovillig att behandla begäran eftersom antingen ett enskilt rubrikfält eller alla rubrikfält kollektivt är för stora.</translation>
     </message>
     <message id="libfuoten-err-http-500">
-        <source>Internal server error — An unexpected condition was ancountered on the server.</source>
+        <source>Internal server error — An unexpected condition was encountered on the server.</source>
         <translation>Internt serverfel — Ett oväntat villkor påträffades på servern.</translation>
     </message>
     <message id="libfuoten-err-http-501">


### PR DESCRIPTION
I've been unable to make it past this error, which gave me plenty of time to spot the one-character typo, hah!

Apologies if you would have rather me have submitted this via Transifex, I found it simpler to just fork and clone the repo and then run a string replace ;)